### PR TITLE
add backend support for multiple simultaneous trips

### DIFF
--- a/Payee/AddItemViewController.swift
+++ b/Payee/AddItemViewController.swift
@@ -54,7 +54,9 @@ class AddItemViewController: UIViewController, UITextFieldDelegate {
         self.view.addGestureRecognizer(tapToCloseKeyboard)
         amountTextField.delegate = self
         nextButton.isEnabled = true
-      let summaryTest: Array = LedgerLine.settleUpSummary()
+      
+      //Get summary array
+      let summaryTest: Array = LedgerLine.settleUpSummary(for: tripManager.activeTrip)
        print(summaryTest)
     }
 

--- a/Payee/LedgerLine.h
+++ b/Payee/LedgerLine.h
@@ -20,7 +20,8 @@
 @property (nonatomic) float tab;
 @property (nonatomic) float pay;
 
-+(NSArray*)settleUpSummary;
++(NSArray*)settleUpSummaryForTrip: (Trip*)trip;
++(NSArray*)budListForTrip: (Trip*)trip;
 
 +(void)clearLedger;
 

--- a/Payee/LedgerLine.m
+++ b/Payee/LedgerLine.m
@@ -10,11 +10,12 @@
 
 @implementation LedgerLine
 
-+(NSArray*)settleUpSummary
++(NSArray*)settleUpSummaryForTrip: (Trip*)trip
 {
   RLMRealm *realm = [RLMRealm defaultRealm];
   RLMResults *buddies = [Buddy allObjects];
-  RLMResults *ledgers = [LedgerLine allObjects];
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"trip == %@",trip ];
+  RLMResults *ledgers = [LedgerLine objectsWithPredicate:predicate];
   NSMutableArray *buddySummaryArray = [[NSMutableArray alloc]init];
   for (Buddy *buddy in buddies)
   {
@@ -32,6 +33,19 @@
     [buddySummaryArray insertObject:buddyLedgerSummary atIndex:0];
   }
   return buddySummaryArray;
+}
+
++(NSArray*)budListForTrip: (Trip*)trip
+{
+  RLMRealm *realm = [RLMRealm defaultRealm];
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"trip == %@",trip ];
+  RLMResults *results = [LedgerLine objectsWithPredicate:predicate];
+  NSMutableArray *tripBuddies = [[NSMutableArray alloc]init];
+  for (LedgerLine* result in results)
+  {
+    [tripBuddies addObject:result];
+  }
+  return tripBuddies;
 }
 
 +(void)clearLedger


### PR DESCRIPTION
If you want to enable multiple trips, just create a trip object and set it as the "active trip" in tripManager.  It will filter Ledgers and Buddies for the active trip only.