### PR TITLE
fixed bug where payer's ccontribution was not recorded if not listed …

### DIFF
--- a/Payee/TripManager.swift
+++ b/Payee/TripManager.swift
@@ -23,17 +23,16 @@ class TripManager: CanCreateTransactionDelegate {
     // Note, if the payer is not listed among the payees, his payment will currently not be recorded.
     let meal: Meal = Meal.init(name: transactionName, andExpense: expenseAmount)
     let payer: Buddy = Buddy.newOr(matchingNameString: payerName)
+    let _: LedgerLine = LedgerLine.init(trip: activeTrip, meal: meal, buddy: payer, tab: 0.00, andPay: expenseAmount)
     for buddyNameAndPortion in arrayOfbuddyNamesAndPortions
     {
       let buddyName = buddyNameAndPortion.0
       let buddy: Buddy = Buddy.newOr(matchingNameString: buddyName)
-      var pay: Float = 0.00;
-      if(payer.isEqual(to: buddy))
-      {
-        pay = expenseAmount
-      }
+      let pay: Float = 0.00;
       let _: LedgerLine = LedgerLine.init(trip: activeTrip, meal: meal, buddy: buddy, tab: buddyNameAndPortion.1, andPay: pay)
     }
+
+    
   }
 }
 


### PR DESCRIPTION
…in buddies list

Basically added a separate transaction for the payer, so they are listed twice in each meal: once with a tab, and once with a pay.